### PR TITLE
(kb0286) Add task to change puppet daemon runmode enabled | disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To view the available actions and parameters, on the command line, run `puppet t
 
 * [`kb0267`](https://support.puppet.com/hc/en-us/articles/360003883933)
 * [`kb0236`](https://support.puppet.com/hc/en-us/articles/360001060434)
+* [`kb0286`](https://support.puppet.com/hc/en-us/articles/360006721014)
 
 
 

--- a/tasks/kb0286.json
+++ b/tasks/kb0286.json
@@ -1,0 +1,15 @@
+{
+  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0286 - https://support.puppet.com/hc/en-us/articles/360006721014",
+  "supports_noop": false,
+  "parameters": {
+    "puppet_mode": {
+      "description": "Can be either `enable` or `disable`, the mode to put the daemon in",
+      "type": "Enum['enable','disable']"
+    },
+    "reason": {
+      "description": "An optional message string to pass that will be added to disabled agents.  Shows up in syslog.",
+      "type": "Optional[String[1]]"
+    }
+  }
+}
+

--- a/tasks/kb0286.sh
+++ b/tasks/kb0286.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# shellcheck disable=SC2230
+
+declare PT_reason
+declare PT_puppet_mode
+
+LOCKFILE="$(puppet config print vardir)/state/agent_disabled.lock"
+
+if [[ $PT_puppet_mode == "enable" ]]
+then
+  if [ -e "$LOCKFILE" ]
+  then
+    puppet agent --enable
+    echo "enabled puppet on $(puppet config print certname)"
+  else
+    echo "puppet already enabled on $(puppet config print certname)"
+  fi
+elif [[ $PT_puppet_mode == "disable" ]]
+then
+  if [ -e "$LOCKFILE" ]
+  then
+    echo "puppet daemon already disabled on $(puppet config print certname)"
+    cat "$(puppet config print vardir)/state/agent_disabled.lock"
+  else
+    puppet agent --disable "$PT_reason"
+    echo "disabled puppet on $(puppet config print certname)"
+    cat "$(puppet config print vardir)/state/agent_disabled.lock"
+  fi
+else
+  echo "parameter puppet_mode must be either enable or disable"
+  exit 1
+fi


### PR DESCRIPTION
(kb0286) Add task to change puppet daemon "runmode" enabled || disabled

This task can either disable or enable the puppet daemon depending on user input.  Attempting to change the status when it is already in the desired state returns a message to that effect.

When the task disable the daemon it will print out the reason it was disabled or the default message "no reason given"

