### PR TITLE
(PDK-1090) Test task names

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -14,6 +14,14 @@ Rakefile:
            end
          end
        end
+    - |
+       desc 'Check task names'
+        task :tasknames do
+          errors = Dir['tasks/**/*'].map do |task|
+              "Task name \"#{task}\" is invalid" if File.basename(task) !~ /\A[a-z][a-z0-9_]*\.[a-z0-9_]+\Z/
+          end.compact
+          abort errors.join("\n") if errors.any?
+       end
 
 .travis.yml:
   branches:
@@ -21,7 +29,7 @@ Rakefile:
   deploy: false
   includes:
     - 
-      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop shellcheck"
+      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop shellcheck tasknames"
   remove_includes:
     -
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   fast_finish: true
   include:
     -
-      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop shellcheck"
+      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop shellcheck tasknames"
 branches:
   only:
     - master

--- a/Rakefile
+++ b/Rakefile
@@ -82,3 +82,11 @@ task :shellcheck do
   end
 end
 
+desc 'Check task names'
+ task :tasknames do
+   errors = Dir['tasks/**/*'].map do |task|
+       "Task name \"#{task}\" is invalid" if File.basename(task) !~ /\A[a-z][a-z0-9_]*\.[a-z0-9_]+\Z/
+   end.compact
+   abort errors.join("\n") if errors.any?
+end
+


### PR DESCRIPTION
Prior to this PR, the task names were not validated. This commit
updates the creates a rake task to check that the puppet task names
are compliant with the naming rules. *Note* that this is a workaround to
PDK-1090 and does not affect `pdk validate`. To use it run `bundle exec
rake tasknames`.

The naming rules are in https://puppet.com/docs/bolt/0.x/writing_tasks.html#concept-676 and the files are tested against the `\A[a-z][a-z0-9_]*\.[a-z0-9_]+\Z` regex. I am also checking the file extension to be lowercase as well.

Example output:

~~~
$ bundle exec rake tasknames
Task name "tasks/123.json" is invalid
Task name "tasks/kb1234" is invalid
Task name "tasks/kb123_Sometask.sh" is invalid
Task name "tasks/kb1234-something.sh" is invalid
~~~