### PR TITLE
Adding SSL dir backup to task kb0263

### DIFF
--- a/tasks/kb0263_rename_pe_master.sh
+++ b/tasks/kb0263_rename_pe_master.sh
@@ -26,6 +26,8 @@ stopsvc() {
 
 # main
 
+tar -cvf "/etc/puppetlabs/puppet/ssl_$(date +%Y-%m-%d-%M-%S).tar.gz" /etc/puppetlabs/puppet/ssl
+
 grep reverse-proxy-ca-service /etc/puppetlabs/puppetserver/bootstrap.cfg 2>&1 /dev/null
 if [ $? -eq 0 ]; then
   echo "Target server appears to be a PE compile master.  This script is intended to be targeted only at a PE Master of Masters.  Exiting."


### PR DESCRIPTION
The manual instructions for this KB tell you to back up the SSL dir.  Might as well have the task do it.