### PR TITLE
Add master certificate regeneration task

### DIFF
--- a/tasks/kb0299_regen_master_cert.json
+++ b/tasks/kb0299_regen_master_cert.json
@@ -1,0 +1,11 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article - https://support.puppet.com/hc/en-us/articles/360008505193",
+  "parameters": {
+    "dnsaltname_override": {
+      "description": "Override to prevent existing DNS alt name carryover.  Will force the use of only the DNS alt names present in pe.conf.",
+      "type": "Optional[Boolean]"
+    }
+  }
+}

--- a/tasks/kb0299_regen_master_cert.sh
+++ b/tasks/kb0299_regen_master_cert.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# shellcheck disable=2181
+# shellcheck disable=2013
+declare PT_dnsaltname_override
+CERTNAME="$(puppet config print certname)"
+PUPPETCMD="/opt/puppetlabs/bin/puppet"
+PATH=/opt/puppetlabs/bin:$PATH
+
+backup_ssl() {
+  tar -cvf "/etc/puppetlabs/puppet/ssl_$(date +%Y-%m-%d-%M-%S).tar.gz" /etc/puppetlabs/puppet/ssl /etc/puppetlabs/puppetdb/ssl /opt/puppetlabs/server/data/console-services/certs /opt/puppetlabs/server/data/postgresql/9.6/data/certs /etc/puppetlabs/orchestration-services/ssl
+}
+
+exit_if_compile_master() {
+  grep reverse-proxy-ca-service /etc/puppetlabs/puppetserver/bootstrap.cfg 2>&1 /dev/null
+  if [ $? -eq 0 ]; then
+    echo "Target server appears to be a PE compile master.  This script is intended to be targeted only at a PE Master of Masters.  Exiting."
+    exit -1
+  elif [ $? -eq 2 ]; then
+    echo "Target server does not appear to be a PE master.  This script is intended to be targeted only at a PE Master of Masters.  Exiting."
+    exit -1
+  fi
+}
+
+check_dns_alt_names() {
+  str=$(puppet cert list "${CERTNAME}")
+  
+  for host in $(grep -oP '(?<="DNS:)(.*?)(?<=")' <<<"${str}"); do
+    tmphost="$(echo "${host}"|cut -d'"' -f 1)"
+    if [ "$tmphost" == "$CERTNAME" ] || [ "$tmphost" == "puppet" ]
+    then
+      continue
+    fi
+    if ! grep "pe_install::puppet_master_dnsaltname.*${tmphost}" /etc/puppetlabs/enterprise/conf.d/pe.conf > /dev/null 2>&1
+    then
+      echo "'${tmphost}' is set up as a DNS alt name in the existing certificate, but is not present in the 'pe_install::puppet_master_dnsaltnames' setting of '/etc/puppetlabs/enterprise/conf.d/pe.conf'.  Please add it to continue, or use the 'dnsaltname_override' task parameter to skip this check."
+      exit -1
+    fi
+  done
+}
+
+# main
+
+exit_if_compile_master
+
+if ! "$PT_dnsaltname_override"
+then
+  check_dns_alt_names
+fi
+
+if [ ! -x $PUPPETCMD ]; then
+  echo "Unable to locate executable Puppet command at ${PUPPETCMD}"
+  exit -1
+fi
+
+# Back up the SSL directories
+backup_ssl
+
+rm -f "/opt/puppetlabs/puppet/cache/client_data/catalog/${CERTNAME}.json"
+
+$PUPPETCMD cert clean "${CERTNAME}"
+
+$PUPPETCMD infrastructure configure --no-recover
+$PUPPETCMD agent -t
+
+if [ $? -eq 2 ]; then
+  exit 0
+fi


### PR DESCRIPTION
There is no KB article associated with this task, so I named it "other_".

This task will regenerate a master's certificate.  Due to service restarts, it will return an error
when run under `puppet task`, but will work anyway.  If run using bolt's ssh transport, this 
error can be avoided.

This task will check to if all dnsaltnames present in the existing certificate are
included in pe.conf to ensure they are rolled into the new one.  This is a boolean to 
override this behavior.