### PR TITLE
(SUP-602) Update task for changing log level

### DIFF
--- a/tasks/kb0009_change_pe_service_loglevel.json
+++ b/tasks/kb0009_change_pe_service_loglevel.json
@@ -4,12 +4,12 @@
   "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article - https://support.puppet.com/hc/en-us/articles/115000177368",
   "parameters": {
     "loglevel": {
-      "description": "The level of log to be set",
-      "type": "Enum[debug, info]"
+      "description": "The level to which the logging will be set",
+      "type": "Enum[trace, debug, info, warn, error]"
     },
-    "peservice": {
+    "service": {
       "description": "PE service",
-      "type": "Enum[puppetserver, puppetdb, consoleservices, orchestrationservices]"
+      "type": "Enum[puppetserver, puppetdb, console-services, orchestration-services]"
     }
   }
 }

--- a/tasks/kb0009_change_pe_service_loglevel.sh
+++ b/tasks/kb0009_change_pe_service_loglevel.sh
@@ -1,54 +1,13 @@
 #!/bin/bash
+# shellcheck disable=1117
 
-# Puppet Task Name: 
-#
-# This is where you put the shell code for your task.
-#
-# You can write Puppet tasks in any language you want and it's easy to
-# adapt an existing Python, PowerShell, Ruby, etc. script. Learn more at:
-# https://puppet.com/docs/bolt/0.x/writing_tasks.html
-#
-# Puppet tasks make it easy for you to enable others to use your script. Tasks
-# describe what it does, explains parameters and which are required or optional,
-# as well as validates parameter type. For examples, if parameter "instances"
-# must be an integer and the optional "datacenter" parameter must be one of
-# portland, sydney, belfast or singapore then the .json file
-# would include:
-#   "parameters": {
-#     "instances": {
-#       "description": "Number of instances to create",
-#       "type": "Integer"
-#     },
-#     "datacenter": {
-#       "description": "Datacenter where instances will be created",
-#       "type": "Enum[portland, sydney, belfast, singapore]"
-#     }
-#   }
-# Learn more at: https://puppet.com/docs/bolt/0.x/writing_tasks.html#ariaid-title11
-#
 # Adjust PE services log level
 
 declare PT_loglevel
-declare PT_peservice
+declare PT_service
 loglevel=$PT_loglevel
-peservice=$PT_peservice
+service=$PT_service
 
-if [ "$peservice" = "consoleservices" ]
-then
- peservice="console-services"
-elif [ "$peservice" = "orchestrationservices" ]
-then
- peservice="orchestration-services"
-fi
-
-if [ -e "/etc/sysconfig/pe-puppetserver" ] || [ -e "/etc/default/pe-puppetserver" ] # check if node is Puppet Master
-then
- echo "Puppetmaster node detected - EL, updating $peservice log level to $loglevel "   #Log Line to StdOut for the Console
- FACTER_level="$loglevel" FACTER_service="$peservice" puppet apply -e "augeas {'toggle logging level': incl => \"/etc/puppetlabs/$::service/logback.xml\", lens => 'Xml.lns', context => \"/files/etc/puppetlabs/$::service/logback.xml/configuration/root/#attribute\", changes => \"set level \'$::level\'\"}~> service {\"pe-$::service\": ensure => running }"
- echo "Updated $peservice log level to $loglevel"
-
-else
-  echo  "-Not a Puppet MASTER node exiting"
-
-fi
+echo "Updating 'pe-${service}' log level to '${loglevel}'"   #Log Line to StdOut for the Console
+FACTER_level="${loglevel}" FACTER_service="${service}" puppet apply -e "augeas {'toggle logging level': incl => \"/etc/puppetlabs/$::service/logback.xml\", lens => 'Xml.lns', context => \"/files/etc/puppetlabs/$::service/logback.xml/configuration/root/#attribute\", changes => \"set level \'$::level\'\"}~> service {\"pe-$::service\": ensure => running }"
 echo " -- KB#0009 Task ended   $(date +%s) --"


### PR DESCRIPTION
- Added trace as a valid log level
- shortened the parameter from peservice to service
- added the dash back to the service names to make them match up with the actual service names at the OS level
- Removed boilerplate comments
- Removed the check for the target being a Puppet master, since this can be run against any mode type.
- Fixed shellcheck errors