### PR TITLE
(maint) Add task KB number to display on the forge

### DIFF
--- a/tasks/kb0009_change_pe_service_loglevel.json
+++ b/tasks/kb0009_change_pe_service_loglevel.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article - https://support.puppet.com/hc/en-us/articles/115000177368",
+  "description": "KB0009 Change PE Service Loglevel - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0009 - https://support.puppet.com/hc/en-us/articles/115000177368",
   "parameters": {
     "loglevel": {
       "description": "The level to which the logging will be set",

--- a/tasks/kb0149_resolve_stack_level_too_deep.json
+++ b/tasks/kb0149_resolve_stack_level_too_deep.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0149 - https://support.puppet.com/hc/en-us/articles/218763948",
+  "description": "KB0149 Resolve Stack Level Too Deep - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0149 - https://support.puppet.com/hc/en-us/articles/218763948",
   "parameters": {
   }
 }

--- a/tasks/kb0236_set_cache_paths_to_default.json
+++ b/tasks/kb0236_set_cache_paths_to_default.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0236 - https://support.puppet.com/hc/en-us/articles/360001060434",
+  "description": "KB0236 Set Cache Paths To Default - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0236 - https://support.puppet.com/hc/en-us/articles/360001060434",
   "parameters": {
   }
 }

--- a/tasks/kb0244_disable_mco_logrotate.json
+++ b/tasks/kb0244_disable_mco_logrotate.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0244 - https://support.puppet.com/hc/en-us/articles/360002051354",
+  "description": "KB0244 Disable MCO Logrotate - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0244 - https://support.puppet.com/hc/en-us/articles/360002051354",
   "parameters": {
   }
 }

--- a/tasks/kb0263_rename_pe_master.json
+++ b/tasks/kb0263_rename_pe_master.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0263 - https://support.puppet.com/hc/en-us/articles/360003489634",
+  "description": "KB0263 Rename PE Master - This task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0263 - https://support.puppet.com/hc/en-us/articles/360003489634",
   "parameters": {
   }
 }

--- a/tasks/kb0267_clear_file_sync_locks.json
+++ b/tasks/kb0267_clear_file_sync_locks.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0267 - https://support.puppet.com/hc/en-us/articles/360003883933",
+  "description": "KB0267 Clear File Sync Locks - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0267 - https://support.puppet.com/hc/en-us/articles/360003883933",
   "parameters": {
   }
 }

--- a/tasks/kb0285_find_disabled_agents.json
+++ b/tasks/kb0285_find_disabled_agents.json
@@ -1,5 +1,6 @@
 {
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0285 - https://support.puppet.com/hc/en-us/articles/360006717334",
+  "puppet_task_version": 1,
+  "description": "KB0285 Find Disabled Agents - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0285 - https://support.puppet.com/hc/en-us/articles/360006717334",
   "supports_noop": false
 }
 

--- a/tasks/kb0286_change_puppet_daemon_runmode.json
+++ b/tasks/kb0286_change_puppet_daemon_runmode.json
@@ -1,5 +1,6 @@
 {
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0286 - https://support.puppet.com/hc/en-us/articles/360006721014",
+  "puppet_task_version": 1,
+  "description": "KB0286 Change Puppet Daemon Runmode - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0286 - https://support.puppet.com/hc/en-us/articles/360006721014",
   "supports_noop": false,
   "parameters": {
     "puppet_mode": {

--- a/tasks/kb0287_check_db_table_sizes.json
+++ b/tasks/kb0287_check_db_table_sizes.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This task is to be used in conjunction with Puppet Enterprise Knowledge Base Article - https://support.puppet.com/hc/en-us/articles/360006922673",
+  "description": "KB0287 Check DB Table Sizes - This task is to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0287 - https://support.puppet.com/hc/en-us/articles/360006922673",
   "parameters": {
     "dbname": {
       "description": "The name of the db to connect to",

--- a/tasks/kb0298_run_code_deploy.json
+++ b/tasks/kb0298_run_code_deploy.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article - https://support.puppet.com/hc/en-us/articles/360008192734",
+  "description": "KB0298 Run Code Deploy - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0298 - https://support.puppet.com/hc/en-us/articles/360008192734",
   "parameters": {
     "environment": {
       "description": "The name of the environment to deploy",

--- a/tasks/kb0299_regen_master_cert.json
+++ b/tasks/kb0299_regen_master_cert.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article - https://support.puppet.com/hc/en-us/articles/360008505193",
+  "description": "KB0299 Regen Master Cert - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0299 - https://support.puppet.com/hc/en-us/articles/360008505193",
   "parameters": {
     "dnsaltname_override": {
       "description": "Override to prevent existing DNS alt name carryover.  Will force the use of only the DNS alt names present in pe.conf.",


### PR DESCRIPTION
Prior to this commit, the task view on the forge did not differentiate
between the tasks on the page. This made it very difficult to find out
the details for a particular task. This commit adds the task name to the
beginning of the description. This commit also adds the tasks version
number for the metadata files that were missing it.

Below is a screenshot of what it currently looks like. 

<img width="846" alt="tasks view" src="https://user-images.githubusercontent.com/25229952/45327615-1701db00-b50d-11e8-9dfb-16a811ffd650.png">
