### PR TITLE
Updating kb0263 script for 2019.0.0

### DIFF
--- a/tasks/kb0263_rename_pe_master.sh
+++ b/tasks/kb0263_rename_pe_master.sh
@@ -74,6 +74,10 @@ setfilecontents /etc/puppetlabs/activemq/activemq.xml "<beans></beans>"
 
 $PUPPETCMD infrastructure configure --no-recover
 $PUPPETCMD node purge "$OLDNAME"
+puppet_version=$("${PUPPET_BIN_DIR?}/puppet" --version)
+if [[ ${puppet_version%%.*} -ge 6 ]];then
+  find /etc/puppetlabs/puppet/ssl -name "$OLDNAME.pem" -delete
+fi
 $PUPPETCMD agent -t
 
 if [ $? -eq 2 ]; then


### PR DESCRIPTION
The puppet node purge command used to delete the certs from the ssldir
in previous releases, but no longer does in 2019.0.0.  To bring the
script into complete parity, this commit adds a find/delete to get
rid of the leftover certs after the node purge if Puppet 6 is
detected.