### PR TITLE
Check for the correct string in results.values.all?

### DIFF
--- a/tasks/kb0317b_purge_node.rb
+++ b/tasks/kb0317b_purge_node.rb
@@ -48,4 +48,4 @@ end
 
 puts results.to_json
 
-exit(results.values.all? { |v| v[:result] == 'Certificate removed' }) ? 0 : 1
+exit(results.values.all? { |v| v[:result] == 'Node purged' }) ? 0 : 1


### PR DESCRIPTION
```root@pe-201901-master:~/Boltdir# bolt task run support_tasks::kb0317b_purge_node --nodes localhost agent_certnames=pe-201901-agent.platform9.puppet.net
Started on localhost...
Finished on localhost:
  {
    "pe-201901-agent.platform9.puppet.net": {
      "result": "Node purged"
    }
  }
Successful on 1 node: localhost
Ran on 1 node in 3.48 seconds
```