### PR TITLE
(MAINT) Update project page to point to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "A module used to deliver Tasks for the solutions & configurations described in the PE Support Knowledgebase https://support.puppet.com/hc/en-us",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/support-tasks",
-  "project_page": "https://support.puppet.com/hc/en-us",
+  "project_page": "https://github.com/puppetlabs/support-tasks",
   "issues_url": "https://github.com/puppetlabs/support-tasks/issues",
   "dependencies": [
 


### PR DESCRIPTION
Prior to this commit, the project url on the forge linked to the support portal.  

After this commit, the project url on the forge links to the github project.