### PR TITLE
(PE-28217) replace references to non-structured legacy facts

### DIFF
--- a/docs/kb0337_REFERENCE.md
+++ b/docs/kb0337_REFERENCE.md
@@ -37,7 +37,7 @@ $ cat pdb.yaml
 query: "inventory[certname] {}"
 groups:
 - name: windows
-  query: "inventory[certname] { facts.osfamily = 'windows' }"
+  query: "inventory[certname] { facts.os.family = 'windows' }"
   config:
     transport: winrm
     winrm:
@@ -64,7 +64,7 @@ $ cat ~/.puppetlabs/bolt/inventory.yaml
 query: inventory[certname] {}
 groups:
 - name: windows
-  query: inventory[certname] { facts.osfamily = 'windows' }
+  query: inventory[certname] { facts.os.family = 'windows' }
   config:
     transport: winrm
     winrm:


### PR DESCRIPTION
It's a best practice to use structured facts instead of legacy facts.
Legacy facts will someday go away.