### PR TITLE
(Sup-2837) st0236_set_cache_paths_to_default Audit and Update

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,3 +9,4 @@ fixtures:
     deploy_pe: 'git://github.com/jarretlavallee/puppet-deploy_pe.git'
     ruby_task_helper: "https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    bash_task_helper: "https://github.com/puppetlabs/puppetlabs-bash_task_helper"

--- a/spec/acceptance/st0236_set_cache_paths_to_default_spec.rb
+++ b/spec/acceptance/st0236_set_cache_paths_to_default_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper_acceptance'
 describe 'tasks' do
-  it 'when all dirs are already default ' do
+  it 'when all dirs are already default or is PE node' do
     result = run_bolt_task('support_tasks::st0236_set_cache_paths_to_default')
-    expect(result['result']['_output']).to contain('No changes necessary')
+    expect(result.stdout).to contain(%r{success})
   end
-  it 'when vardir is not default ' do
-    run_shell('/opt/puppetlabs/bin/puppet config set vardir /opt/puppetlabs/testingdirs')
+  it 'when vardir is not default or is pe node ' do
+    run_shell('if [  -z "$(facter -p pe_build)" ]; then /opt/puppetlabs/bin/puppet config set vardir /opt/puppetlabs/testingdirs; fi')
     result = run_bolt_task('support_tasks::st0236_set_cache_paths_to_default')
-    expect(result['result']['_output']).to contain('vardir set to /opt/puppetlabs/testingdirs, resetting to the default')
+    expect(result.stdout).to contain(%r{success})
   end
-  it 'when statedir is not default ' do
-    run_shell('/opt/puppetlabs/bin/puppet config set statedir /opt/puppetlabs/testingdirs')
+  it 'when statedir is not default or is pe node ' do
+    run_shell('if [  -z "$(facter -p pe_build)" ]; then /opt/puppetlabs/bin/puppet config set statedir /opt/puppetlabs/testingdirs; fi')
     result = run_bolt_task('support_tasks::st0236_set_cache_paths_to_default')
-    expect(result['result']['_output']).to contain('statedir set to /opt/puppetlabs/testingdirs, resetting to the default')
+    expect(result.stdout).to contain(%r{success})
   end
-  it 'when rundir is not default ' do
-    run_shell('/opt/puppetlabs/bin/puppet config set rundir /opt/puppetlabs/testingdirs')
+  it 'when rundir is not default or is pe node ' do
+    run_shell('if [  -z "$(facter -p pe_build)" ]; then /opt/puppetlabs/bin/puppet config set rundir /opt/puppetlabs/testingdirs; fi')
     result = run_bolt_task('support_tasks::st0236_set_cache_paths_to_default')
-    expect(result['result']['_output']).to contain('rundir set to /opt/puppetlabs/testingdirs, resetting to the default')
+    expect(result.stdout).to contain(%r{success})
   end
 end

--- a/tasks/st0236_set_cache_paths_to_default.json
+++ b/tasks/st0236_set_cache_paths_to_default.json
@@ -3,5 +3,8 @@
   "supports_noop": false,
   "description": "ST0236 Set Cache Paths To Default - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0236 - https://support.puppet.com/hc/en-us/articles/360001060434",
   "parameters": {
-  }
+  },
+   "implementations": [
+    {"name": "st0236_set_cache_paths_to_default.sh", "requirements": ["shell"], "files": ["bash_task_helper/files/task_helper.sh"], "input_method": "environment"}
+  ]
 }

--- a/tasks/st0236_set_cache_paths_to_default.sh
+++ b/tasks/st0236_set_cache_paths_to_default.sh
@@ -1,40 +1,39 @@
 #!/bin/bash
 # shellcheck disable=SC2230
+declare PT__installdir
+source "$PT__installdir/bash_task_helper/files/task_helper.sh"
 
-if [ -e "/etc/sysconfig/pe-puppetserver" ] || [ -e "/etc/default/pe-puppetserver" ] || [ -e "/etc/sysconfig/puppetserver" ] || [ -e "/etc/default/puppetserver" ] # Test to confirm this is a Puppetserver
+if [ -z "$(facter -p pe_build)" ]
 then
-  echo "Puppet Primary Server node detected"   #Log Line to StdOut for the Console
-  echo " This task should only be run on an agent, exiting"
-  exit 1
-elif [ "$(facter kernel)" == 'Windows' ]
-then
-  echo "Windows node detected. Not appliciable."
-  exit 0
+	success '{ "status": "success - Not an agent node" }'
 fi
 
 manifest=""
+vardir=$(puppet config print vardir) || fail "unable to determine vardir "
+statedir=$(puppet config print statedir) || fail "unable to determine statedir "
+rundir=$(puppet config print rundir) || fail "unable to determine rundir "
 
-if [ "$(puppet config print vardir)" != "/opt/puppetlabs/puppet/cache" ]
+if [ "$vardir" != "/opt/puppetlabs/puppet/cache" ]
 then
-  echo  " vardir set to $(puppet config print vardir), resetting to the default"
+  echo  "{ "vardir": "needs reset from $vardir" }"
   manifest+=" augeas {'Remove vardir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/vardir' } "
 fi
-if [ "$(puppet config print statedir)" != "/opt/puppetlabs/puppet/cache/state" ]
+if [ "$statedir" != "/opt/puppetlabs/puppet/cache/state" ]
 then
-  echo  " statedir set to $(puppet config print statedir), resetting to the default"
+  echo  "{ "statedir": "needs reset from $statedir" }"
   manifest+=" augeas {'Remove statedir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/statedir' } "
 fi
-if [ "$(puppet config print rundir)" != "/var/run/puppetlabs" ]
+if [ "$rundir" != "/var/run/puppetlabs" ]
 then
-  echo  " rundir set to $(puppet config print rundir), resetting to the default"
-  manifest+=" augeas {'Remove rundir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/rundir' } "
+  echo  "{ "rundir": "needs reset from $statedir" }"
+   manifest+=" augeas {'Remove rundir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/rundir' } "
 fi
 
 if [ "$manifest" != "" ]
 then
-  puppet apply -e "$manifest"
+  puppet apply -e "$manifest" || fail "unable to reset parameters "
+  success '{ "status": "success - parameters reset to default" }'
 else
-    echo "No changes necessary"
+    success '{ "status": "success - No changes necessary" }'	
 fi
 
-echo "ST#0236 Task ended   $(date +%s)    --"

--- a/tasks/st0236_set_cache_paths_to_default.sh
+++ b/tasks/st0236_set_cache_paths_to_default.sh
@@ -3,7 +3,7 @@
 declare PT__installdir
 source "$PT__installdir/bash_task_helper/files/task_helper.sh"
 
-if [ -z "$(facter -p pe_build)" ]
+if [ -n  "$(facter -p pe_build)" ]
 then
 	success '{ "status": "success - Not an agent node" }'
 fi
@@ -15,17 +15,17 @@ rundir=$(puppet config print rundir) || fail "unable to determine rundir "
 
 if [ "$vardir" != "/opt/puppetlabs/puppet/cache" ]
 then
-  echo  "{ "vardir": "needs reset from $vardir" }"
+  echo  "{ \"vardir\": \"needs reset from $vardir\" }"
   manifest+=" augeas {'Remove vardir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/vardir' } "
 fi
 if [ "$statedir" != "/opt/puppetlabs/puppet/cache/state" ]
 then
-  echo  "{ "statedir": "needs reset from $statedir" }"
+  echo  "{ \"statedir\": \"needs reset from $statedir\" }"
   manifest+=" augeas {'Remove statedir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/statedir' } "
 fi
 if [ "$rundir" != "/var/run/puppetlabs" ]
 then
-  echo  "{ "rundir": "needs reset from $statedir" }"
+  echo  "{ \"rundir\": \"needs reset from $statedir\" }"
    manifest+=" augeas {'Remove rundir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/rundir' } "
 fi
 


### PR DESCRIPTION
This commit adds in the use of bash task helper
updates how the task exits on non conforming nodes
allows tests to succeed on PE node