### PR TITLE
(SUP-2923) Replace unencrypted git protocol in .fixtures.yaml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,12 @@
 ---
 fixtures:
   repositories:
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
-    bootstrap: "https://github.com/puppetlabs/puppetlabs-bootstrap"
-    puppet_conf: "https://github.com/puppetlabs/puppetlabs-puppet_conf"
-    deploy_pe: 'git://github.com/jarretlavallee/puppet-deploy_pe.git'
-    ruby_task_helper: "https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper"
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    bash_task_helper: "https://github.com/puppetlabs/puppetlabs-bash_task_helper"
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
+    provision: 'https://github.com/puppetlabs/provision'
+    bootstrap: 'https://github.com/puppetlabs/puppetlabs-bootstrap'
+    puppet_conf: 'https://github.com/puppetlabs/puppetlabs-puppet_conf'
+    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'
+    ruby_task_helper: 'https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    bash_task_helper: 'https://github.com/puppetlabs/puppetlabs-bash_task_helper'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.