### PR TITLE
SUP-3551 Change password to sensitive

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-bash_task_helper",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/tasks/st0370_generate_token.json
+++ b/tasks/st0370_generate_token.json
@@ -9,9 +9,8 @@
     },
     "password": {
       "description": "PE RBAC User Password",
-      "type": "String"
+      "type": "String",
+      "sensitive": true
     }
-    
-  
-}
+  }
 }


### PR DESCRIPTION
Changed the password parameter in the generate token task to sensitive so it is obfuscated in the console task details. 
Also increased bash_task_helper version requirements in metadata due to testing on v2 of the module.