### PR TITLE
Sup 4423 - Deprecation of clean_cert tool [st317a]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - [Setup](#setup)
     - [Beginning with support_tasks](#beginning-with-support_tasks)
   - [Usage](#usage)
+  - [Deprecation Notice](#deprecation-notice)
   - [Getting Help](#getting-help)
   - [How to Report an issue or contribute to the module](#how-to-report-an-issue-or-contribute-to-the-module)
 - [Supporting Content](#supporting-content)
@@ -29,6 +30,14 @@ Tasks in this module should only be executed by PE support customers in accompan
 ## Usage
 
 Support customers should follow the instructions in the corresponding knowledge base articles linked below.
+
+## Deprecation Notice
+
+The following tasks are no longer being developed and will be deprecated in a future version:
+
+| Task Name | Alternative |
+|-----------|-------------|
+| st0317a_clean_cert | User [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to remove certifications |
 
 ## Getting Help
 

--- a/tasks/st0317a_clean_cert.rb
+++ b/tasks/st0317a_clean_cert.rb
@@ -6,6 +6,10 @@
 # Parameters:
 #   * agent_certnames - A comma-separated list of agent certificates to clean/remove.
 
+# DEPRECATION:
+# This script is now Deprecated and will be removed in a further update
+# For cert removal using API https://www.puppet.com/docs/puppet/8/server/http_certificate_clean
+
 # Original code by Nate McCurdy
 # https://github.com/natemccurdy/puppet-purge_node
 
@@ -45,7 +49,11 @@ def clean_cert(agent, cmd)
   }
 end
 
-results = {}
+deprecation_msg = "This task is deprecated and has been replaced by the certificate clean api, which provides the same functionality. 
+                   This task will be removed in a future release.  Please see this module's README for more information"
+results = {
+  deprecation: deprecation_msg
+}
 agents = ENV['PT_agent_certnames'].split(',')
 
 agents.each do |agent|
@@ -62,4 +70,4 @@ end
 
 puts results.to_json
 
-exit(results.values.all? { |v| v[:result] == 'Certificate removed' }) ? 0 : 1
+exit(results.values.reject { |v| v == deprecation_msg }.all? { |v| v[:result] == 'Certificate removed' }) ? 0 : 1


### PR DESCRIPTION
SUP-4423 - Deprecation of st0317a_clean_cert tasks

Add deprecation notice to both `tasks/st317a_clean_cert.rb` and `st0317a_clean_cert.json`

And I've started with a chart on the readme