### PR TITLE
Sup 4590 deprecate st0236 set cache paths to default

### DIFF
--- a/tasks/st0236_set_cache_paths_to_default.json
+++ b/tasks/st0236_set_cache_paths_to_default.json
@@ -1,7 +1,7 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "ST0236 Set Cache Paths To Default - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0236 - https://support.puppet.com/hc/en-us/articles/360001060434",
+  "description": "***DEPRECATION NOTICE - This task is unsupported and will be removed in a future version*** - ST0236 Set Cache Paths To Default - This Task to be used in conjunction with Puppet Enterprise Knowledge Base Article KB0236 - https://support.puppet.com/hc/en-us/articles/360001060434",
   "parameters": {
   },
    "implementations": [

--- a/tasks/st0236_set_cache_paths_to_default.sh
+++ b/tasks/st0236_set_cache_paths_to_default.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # shellcheck disable=SC2230
+# DEPRECATION:
+# This script is now Deprecated and will be removed in a further update
 declare PT__installdir
 source "$PT__installdir/bash_task_helper/files/task_helper.sh"
 
 if [ -n  "$(facter -p pe_build)" ]
 then
-	task-suceed "success - Not an agent node"
+	task-suceed "***THIS TASK IS NOW DEPRECATED - Please see README*** - success - Not an agent node"
 fi
 
 manifest=""
@@ -32,8 +34,8 @@ fi
 if [ "$manifest" != "" ]
 then
   puppet apply -e "$manifest" || task-fail "unable to reset parameters"
-  task-succeed "success - parameters reset to default"
+  task-succeed "***THIS TASK IS NOW DEPRECATED - Please see README for information*** - success - parameters reset to default"
 else
-    task-succeed "success - No changes necessary"	
+    task-succeed "***THIS TASK IS NOW DEPRECATED - Please see README for information*** - success - No changes necessary"	
 fi
 


### PR DESCRIPTION
SUp-4590 - Deprecation of st0236_set_cache_paths_to_default

Add deprecation notice to both task/st0236_set_cache_paths_to_default.rb and st0236_clean_cert.json