### PR TITLE
Sup-4590 - Deprecation of set_cache_paths_to_default task [st0236]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The following tasks are no longer being developed and will be deprecated in a fu
 
 | Task Name | Alternative |
 |-----------|-------------|
-| st0317a_clean_cert | User [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to remove certifications |
+| st0236_set_cache_paths_to_default | Use [puppet conf](https://forge.puppet.com/modules/puppetlabs/puppet_conf/readme) |
+| st0317a_clean_cert | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to remove certifications | 
 
 ## Getting Help
 

--- a/tasks/st0236_set_cache_paths_to_default.sh
+++ b/tasks/st0236_set_cache_paths_to_default.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 # shellcheck disable=SC2230
+# DEPRECATION:
+# This script is now Deprecated and will be removed in a further update
 declare PT__installdir
 source "$PT__installdir/bash_task_helper/files/task_helper.sh"
+task-output "deprecation" "This task is deprecated and will be removed in a future release. Please see this module's README for more information"
 
 if [ -n  "$(facter -p pe_build)" ]
 then
-	task-suceed "success - Not an agent node"
+	task-suceed "Not an agent node"
 fi
 
 manifest=""
@@ -26,7 +29,7 @@ fi
 if [ "$rundir" != "/var/run/puppetlabs" ]
 then
   echo  "{ \"rundir\": \"needs reset from $statedir\" }"
-   manifest+=" augeas {'Remove rundir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/rundir' } "
+  manifest+=" augeas {'Remove rundir': changes => 'rm etc/puppetlabs/puppet/puppet.conf/main/rundir' } "
 fi
 
 if [ "$manifest" != "" ]
@@ -34,6 +37,6 @@ then
   puppet apply -e "$manifest" || task-fail "unable to reset parameters"
   task-succeed "success - parameters reset to default"
 else
-    task-succeed "success - No changes necessary"	
+  task-succeed "success - No changes necessary"	
 fi
 


### PR DESCRIPTION
SUp-4590 - Deprecation of st0236_set_cache_paths_to_default

Add deprecation notice to both task/st0236_set_cache_paths_to_default.rb and st0236_clean_cert.json


![image](https://github.com/puppetlabs/support-tasks/assets/23338994/0a26c87a-d853-44d1-b511-fd612ac2e40c)
