### PR TITLE
SUP-4598 - Deprecation of Purge_Node task [st0317b]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The following tasks are no longer being developed and will be deprecated in a fu
 | st0298_run_code_deploy | See [documentation](https://www.puppet.com/docs/pe/latest/code_mgr) for suitable solution |
 | st0305_support_script_and_upload | See [documentation](https://portal.perforce.com/s/article/360009970114) for upload methods. SFTP and MFT are preferred|
 | st0362_download_latest_pe_in_stream |  See [documentation](https://portal.perforce.com/s/article/218822507) for latest version of PE |
-| st0317a_clean_cert | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to remove certifications | 
+| st0317a_clean_cert | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to remove certifications |
+| st0317b_purge_node | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to purge nodes | 
 
 ## Getting Help
 

--- a/tasks/st0317b_purge_node.rb
+++ b/tasks/st0317b_purge_node.rb
@@ -6,6 +6,10 @@
 # Parameters:
 #   * agent_certnames - A comma-separated list of agent certificate names.
 
+# DEPRECATION:
+# This script is now Deprecated and will be removed in a further update
+# For node purge using API https://www.puppet.com/docs/puppet/8/server/http_certificate_clean
+
 # Original code by Nate McCurdy
 # https://github.com/natemccurdy/puppet-purge_node
 
@@ -31,7 +35,12 @@ def purge_node(agent)
   }
 end
 
-results = {}
+deprecation_msg = "This task is deprecated and has been replaced by the certificate clean api, which provides the same functionality.
+                   This task will be removed in a future release.  Please see this module's README for more information"
+
+results = {
+  deprecation: deprecation_msg
+}
 agents = ENV['PT_agent_certnames'].split(',')
 
 agents.each do |agent|
@@ -48,4 +57,4 @@ end
 
 puts results.to_json
 
-exit(results.values.all? { |v| v[:result] == 'Node purged' }) ? 0 : 1
+exit(results.values.reject { |v| v == deprecation_msg }.all? { |v| v[:result] == 'Node purged' }) ? 0 : 1


### PR DESCRIPTION
Deprecation Messaged added into ruby script with README updated, pointing the user towards the CA API.