### PR TITLE
SUP-4601 - Deprecation of Puppet_Commands task [st0371]

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following tasks are no longer being developed and will be deprecated in a fu
 | st0317a_clean_cert | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to remove certifications |
 | st0317b_purge_node | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to purge nodes |
 | st0370_generate_token | Use [puppet access CLI](https://www.puppet.com/docs/pe/latest/rbac_token_auth_intro.html#generate_a_token_using_puppet_access) |
+| st0371_puppet_commands | Use [Pe status check](https://forge.puppet.com/modules/puppetlabs/pe_status_check/readme) |
 
 ## Getting Help
 

--- a/tasks/st0371_puppet_commands.sh
+++ b/tasks/st0371_puppet_commands.sh
@@ -7,6 +7,7 @@ declare PT_command
 command=$PT_command
 
 
+echo "This task is deprecated and will be removed in a future release. Please see this module's README for more information"
 
 if [ -e "/etc/sysconfig/pe-puppetserver" ] || [ -e "/etc/default/pe-puppetserver" ] || [ -e "/etc/sysconfig/puppetserver" ] || [ -e "/etc/default/puppetserver" ] # Test to confirm this is a Puppetserver
 then


### PR DESCRIPTION
Deprecation Notice left within file and README updated to inform user to use PE_STATUS_CHECK