### PR TITLE
SUP-4602 -  Deprecation of OS-Commands task [st0372]

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following tasks are no longer being developed and will be deprecated in a fu
 | st0317b_purge_node | Use [certificate clean](https://www.puppet.com/docs/puppet/7/server/http_certificate_clean) API to purge nodes |
 | st0370_generate_token | Use [puppet access CLI](https://www.puppet.com/docs/pe/latest/rbac_token_auth_intro.html#generate_a_token_using_puppet_access) |
 | st0371_puppet_commands | Use [Pe status check](https://forge.puppet.com/modules/puppetlabs/pe_status_check/readme) |
+| st0372_os_commands |  See documentation on [system configuration](https://portal.perforce.com/s/article/360040232993) |
 
 ## Getting Help
 

--- a/tasks/st0372_os_commands.sh
+++ b/tasks/st0372_os_commands.sh
@@ -2,11 +2,14 @@
 
 #
 
+# DEPRECATION:
+# This script is now Deprecated and will be removed in a further update
 
 declare PT_command
 command=$PT_command
 
 
+echo "This task is deprecated and will be removed in a future release. Please see this module's README for more information"
 
 if [ -e "/etc/sysconfig/pe-puppetserver" ] || [ -e "/etc/default/pe-puppetserver" ] || [ -e "/etc/default/puppetserver" ] || [ -e "/etc/sysconfig/puppetserver" ] # Test to confirm this is a Puppetserver
 then


### PR DESCRIPTION
Deprecation Notice and Readme Updated, tested within PE UI

`Transport: Puppet agent
Start time: 2023-11-09 14:36 Z
Run time: 00:00:00
Succeeded
This task is deprecated and will be removed in a future release. Please see this module's README for more information
Puppetserver node detected
2023-11-09T11:45:33.174Z INFO  [p.p.command] [12-1699530333109-1699530333035] [52 ms] 'store report' puppet v8.3.1 command (d632c15b) processed for pe-server-78e2b8-0.us-west1-a.c.customer-support-scratchpad.internal
 `