### PR TITLE
(SUP-4700) Removal of Unnecessary Table of Contents Reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 #### Table of Contents
 
 - [support_tasks](#support_tasks)
-      - [Table of Contents](#table-of-contents)
   - [Description](#description)
   - [Setup](#setup)
     - [Beginning with support_tasks](#beginning-with-support_tasks)


### PR DESCRIPTION
This PR removes the self referencing 'Table of Contents' tag from the README. This renders in the forge incorrectly, a minor issue but one that can be placed in with the next release. 